### PR TITLE
[placeholder] allow for omission of certain attributes on placeholder clone

### DIFF
--- a/visibility.js
+++ b/visibility.js
@@ -304,6 +304,10 @@ $.fn.visibility = function(parameters) {
               .addClass(className.placeholder)
               .insertAfter($module)
             ;
+            if (settings.omitPlaceholderAttrs)
+            {
+              $placeholder = $placeholder.find('*').addBack().removeAttr(settings.omitPlaceholderAttrs);
+            }
           }
         },
 


### PR DESCRIPTION
if placeholder clone includes `data-reactid` attributes, react will throw:

```
Uncaught Error: Invariant Violation: ReactMount: Two valid but unequal nodes with the same `data-reactid`: .0.0.0.0
```

this fix allows for a call syntax like below which will omit `data-reactid` attributes and skirt error:

```
  componentDidMount() {
    console.log('menu: cdm')
    $(React.findDOMNode(this)).visibility(
      {
        type: 'fixed',
        omitPlaceholderAttrs: 'data-reactid'
      }
    )
  }
```
